### PR TITLE
Add GuildAdsBannerConfiguration for display customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,36 @@ For predictable presentation:
 - Prefer giving the banner enough horizontal space (it targets a max width of 360pt and fixed height of 50pt).
 - Avoid clipping/masking the banner container unless you intentionally want to crop it.
 
+## Customization
+
+### Theme
+
+Match the banner to your app's background with the `theme` parameter:
+
+```swift
+GuildAdsBanner(placementID: "settings_footer", theme: .automatic) // follows system (default)
+GuildAdsBanner(placementID: "settings_footer", theme: .light)     // light backgrounds
+GuildAdsBanner(placementID: "settings_footer", theme: .dark)      // dark backgrounds
+```
+
+### Banner configuration
+
+Use `GuildAdsBannerConfiguration` to adjust visual details:
+
+```swift
+let config = GuildAdsBannerConfiguration(
+    cornerRadius: 8,
+    showCallToAction: false
+)
+
+GuildAdsBanner(
+    placementID: "settings_footer",
+    configuration: config
+)
+```
+
+Available options: `cornerRadius`, `maxWidth`, `showIcon`, `callToActionText`, `showCallToAction`, `horizontalPadding`.
+
 ## Default API base URL
 
 `https://guildads.com`

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -35,14 +35,16 @@ private struct GuildAdsBannerPalette {
 public struct GuildAdsBanner: View {
     private let placementID: String
     private let theme: GuildAdsBannerTheme
+    private let configuration: GuildAdsBannerConfiguration
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
     @StateObject private var viewModel = GuildAdsBannerViewModel()
 
-    public init(placementID: String, theme: GuildAdsBannerTheme = .automatic) {
+    public init(placementID: String, theme: GuildAdsBannerTheme = .automatic, configuration: GuildAdsBannerConfiguration = .default) {
         self.placementID = placementID
         self.theme = theme
+        self.configuration = configuration
     }
 
     public var body: some View {
@@ -167,30 +169,34 @@ public struct GuildAdsBanner: View {
 
     private func bannerCard(for ad: GuildAd) -> some View {
         HStack(spacing: 12) {
-            iconView(for: ad)
+            if configuration.showIcon {
+                iconView(for: ad)
+            }
 
             adTextView(for: ad)
 
             Spacer(minLength: 2)
 
-            Text("Get")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.black)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(Color.white)
-                .clipShape(Capsule())
-                .shadow(color: Color.black.opacity(0.14), radius: 3, x: 0, y: 1)
+            if configuration.showCallToAction {
+                Text(configuration.callToActionText)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.white)
+                    .clipShape(Capsule())
+                    .shadow(color: Color.black.opacity(0.14), radius: 3, x: 0, y: 1)
+            }
         }
-        .padding(12)
-        .padding(.trailing, 20)
-        .frame(maxWidth: GuildAdsBannerLayout.maxWidth)
+        .padding(configuration.horizontalPadding)
+        .padding(.trailing, GuildAdsBannerLayout.adRailWidth)
+        .frame(maxWidth: configuration.maxWidth)
         .frame(minHeight: GuildAdsBannerLayout.height, maxHeight: GuildAdsBannerLayout.height)
         .background(
-            RoundedRectangle(cornerRadius: 14)
+            RoundedRectangle(cornerRadius: configuration.cornerRadius)
                 .fill(palette.cardFillColor)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 14)
+                    RoundedRectangle(cornerRadius: configuration.cornerRadius)
                         .stroke(palette.cardStrokeColor, lineWidth: 1)
                 )
         )
@@ -199,7 +205,7 @@ public struct GuildAdsBanner: View {
         .overlay(alignment: .trailing) {
             adRailView
         }
-        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .clipShape(RoundedRectangle(cornerRadius: configuration.cornerRadius))
     }
 
     private func adTextView(for ad: GuildAd) -> some View {

--- a/Sources/GuildAds/GuildAdsBannerConfiguration.swift
+++ b/Sources/GuildAds/GuildAdsBannerConfiguration.swift
@@ -1,0 +1,33 @@
+// GuildAdsBannerConfiguration.swift
+// GuildAds
+//
+// Created by Tyler Hillsman
+
+import SwiftUI
+
+public struct GuildAdsBannerConfiguration: Sendable {
+    public var cornerRadius: CGFloat
+    public var maxWidth: CGFloat
+    public var showIcon: Bool
+    public var callToActionText: String
+    public var showCallToAction: Bool
+    public var horizontalPadding: CGFloat
+
+    public init(
+        cornerRadius: CGFloat = 14,
+        maxWidth: CGFloat = 360,
+        showIcon: Bool = true,
+        callToActionText: String = "Get",
+        showCallToAction: Bool = true,
+        horizontalPadding: CGFloat = 12
+    ) {
+        self.cornerRadius = cornerRadius
+        self.maxWidth = maxWidth
+        self.showIcon = showIcon
+        self.callToActionText = callToActionText
+        self.showCallToAction = showCallToAction
+        self.horizontalPadding = horizontalPadding
+    }
+
+    public static let `default` = GuildAdsBannerConfiguration()
+}


### PR DESCRIPTION
## Summary
- Add `GuildAdsBannerConfiguration` struct with configurable corner radius, max width, icon visibility, CTA text/visibility, and horizontal padding
- Wire configuration into `GuildAdsBanner` as an optional parameter (defaults preserve existing behavior)
- Replace hardcoded layout values in `bannerCard` with configuration properties
- Add "Customization" section to README covering theme selection and configuration usage

## Test plan
- [ ] Verify `GuildAdsBanner(placementID: "test")` compiles and renders identically to before (default configuration)
- [ ] Verify `GuildAdsBanner(placementID: "test", configuration: .init(cornerRadius: 8, showCallToAction: false))` hides the CTA and uses rounded corners
- [ ] Verify `showIcon: false` omits the icon from the banner
- [ ] Verify custom `callToActionText` renders the provided string

🤖 Generated with [Claude Code](https://claude.com/claude-code)