### PR TITLE
Marquee effect for long titles, improved DEBUG behavior, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://github.com/Guild-Ads/guild-ads-ios
 Or add it to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/Guild-Ads/guild-ads-ios.git", from: "1.0.1")
+.package(url: "https://github.com/Guild-Ads/guild-ads-ios.git", from: "1.0.2")
 ```
 
 Then add `"GuildAds"` to the target's dependency list and `import GuildAds` wherever you need it.

--- a/Sources/GuildAds/GuildAds.swift
+++ b/Sources/GuildAds/GuildAds.swift
@@ -26,6 +26,23 @@ public enum GuildAds {
     }
 
     public static func configure(configuration: GuildAdsConfiguration) {
+        let shouldDisableNetworkingForDebug = _isDebugAssertConfiguration()
+            && ProcessInfo.processInfo.environment["GUILDADS_ENABLE_LIVE_DEBUG"] != "1"
+
+        if shouldDisableNetworkingForDebug {
+            client = nil
+            #if canImport(UIKit)
+            if targetEnvironment(simulator) {
+                print("[GuildAds] DEBUG simulator mode: SDK networking disabled, showing mock banner creative.")
+            } else {
+                print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
+            }
+            #else
+            print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
+            #endif
+            return
+        }
+
         let client = GuildAdsClient(configuration: configuration)
         self.client = client
 

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -314,15 +314,16 @@ public struct GuildAdsBanner: View {
         VStack(alignment: .leading, spacing: 2) {
             GuildAdsMarqueeText(
                 text: ad.title,
-                font: .subheadline.weight(.semibold),
+                font: .system(size: 13, weight: .semibold),
                 color: palette.textColor,
                 measureFont: titleMeasureFont
             )
 
             Text(ad.subtitle)
-                .font(.caption)
+                .font(.system(size: 10))
                 .foregroundStyle(palette.subtitleColor)
                 .lineLimit(2)
+                .lineSpacing(-1)
                 .truncationMode(.tail)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -331,9 +332,9 @@ public struct GuildAdsBanner: View {
     private var titleMeasureFont: GuildAdsBannerPlatformFont {
         #if canImport(UIKit)
         let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .subheadline)
-        return UIFont.systemFont(ofSize: descriptor.pointSize, weight: .semibold)
+        return UIFont.systemFont(ofSize: max(8, descriptor.pointSize - 2), weight: .semibold)
         #elseif canImport(AppKit)
-        return NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
+        return NSFont.systemFont(ofSize: max(8, NSFont.smallSystemFontSize - 2), weight: .semibold)
         #endif
     }
 

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -296,6 +296,12 @@ public struct GuildAdsBanner: View {
     private var cardBackground: some View {
         let shape = RoundedRectangle(cornerRadius: 14)
         if palette.usesGlass {
+            #if os(visionOS)
+            // glassEffect(_:in:) is unavailable on visionOS.
+            shape
+                .fill(.ultraThinMaterial)
+                .overlay(shape.stroke(palette.cardStrokeColor, lineWidth: 1))
+            #else
             if #available(iOS 26, macOS 26, *) {
                 shape
                     .fill(.ultraThinMaterial)
@@ -306,6 +312,7 @@ public struct GuildAdsBanner: View {
                     .fill(.ultraThinMaterial)
                     .overlay(shape.stroke(palette.cardStrokeColor, lineWidth: 1))
             }
+            #endif
         } else if palette.usesVibrantMaterial {
             shape
                 .fill(.thinMaterial)

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -91,6 +91,7 @@ public struct GuildAdsBanner: View {
     private let placementID: String
     private let style: GuildAdsBannerStyle
     private let previewAd: GuildAd?
+    private let debugMockAd: GuildAd?
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
@@ -100,6 +101,7 @@ public struct GuildAdsBanner: View {
         self.placementID = placementID
         self.style = style
         self.previewAd = nil
+        self.debugMockAd = GuildAdsBannerDebugMockFactory.make(placementID: placementID)
         _viewModel = StateObject(wrappedValue: GuildAdsBannerViewModel())
     }
 
@@ -107,6 +109,7 @@ public struct GuildAdsBanner: View {
         self.placementID = previewAd.placementID
         self.style = style
         self.previewAd = previewAd
+        self.debugMockAd = nil
         _viewModel = StateObject(wrappedValue: GuildAdsBannerViewModel(initialAd: previewAd))
     }
 
@@ -138,13 +141,13 @@ public struct GuildAdsBanner: View {
             }
         }
         .task(id: placementID) {
-            guard !isPreviewMode else {
+            guard !isMockMode else {
                 return
             }
             await viewModel.load(placementID: placementID, theme: resolvedTheme)
         }
         .onAppear {
-            guard !isPreviewMode else {
+            guard !isMockMode else {
                 return
             }
             viewModel.beginAppearance()
@@ -153,7 +156,7 @@ public struct GuildAdsBanner: View {
             }
         }
         .onChange(of: viewModel.ad?.id) { _ in
-            guard !isPreviewMode else {
+            guard !isMockMode else {
                 return
             }
             Task {
@@ -195,18 +198,22 @@ public struct GuildAdsBanner: View {
             }
             #endif
         }
-        guard !isPreviewMode else {
+        guard !isMockMode else {
             return
         }
         viewModel.handleTap(placementID: placementID)
     }
 
     private var activeAd: GuildAd? {
-        previewAd ?? viewModel.ad
+        previewAd ?? debugMockAd ?? viewModel.ad
     }
 
     private var isPreviewMode: Bool {
         previewAd != nil
+    }
+
+    private var isMockMode: Bool {
+        previewAd != nil || debugMockAd != nil
     }
 
     private var resolvedTheme: GuildAdsTheme {
@@ -377,6 +384,23 @@ public struct GuildAdsBanner: View {
                     .clipShape(RoundedRectangle(cornerRadius: 8))
             }
         }
+    }
+}
+
+private enum GuildAdsBannerDebugMockFactory {
+    static func make(placementID: String) -> GuildAd? {
+        #if DEBUG
+        return GuildAd(
+            id: "debug_mock_\(placementID)",
+            placementID: placementID,
+            title: "Guild Ads",
+            subtitle: "The indie-friendly, privacy-respecting ad network",
+            iconURL: URL(string: "https://guildads.com/logo-1024.png"),
+            destinationURL: URL(string: "https://guildads.com")!
+        )
+        #else
+        return nil
+        #endif
     }
 }
 
@@ -723,23 +747,7 @@ private final class GuildAdsBannerViewModel: ObservableObject {
 }
 
 #if DEBUG
-#Preview("Marquee Demo (Overflow)") {
-    GuildAdsBanner(
-        previewAd: GuildAd(
-            id: "preview_marquee_demo",
-            placementID: "preview_marquee_demo",
-            title: "This is an intentionally very long banner title to demonstrate marquee scrolling",
-            subtitle: "Marquee should move left continuously when title exceeds width.",
-            iconURL: nil,
-            destinationURL: URL(string: "https://guildads.com")!
-        ),
-        style: .automatic
-    )
-    .frame(width: 320)
-    .padding()
-}
-
-#Preview("All Supabase Campaign Creatives") {
+#Preview("Guild Ads Sample Creative") {
     ScrollView {
         VStack(spacing: 10) {
             ForEach(GuildAdsBannerPreviewFixtures.allAds) { ad in
@@ -754,172 +762,12 @@ private final class GuildAdsBannerViewModel: ObservableObject {
 private enum GuildAdsBannerPreviewFixtures {
     static let allAds: [GuildAd] = [
         GuildAd(
-            id: "2f7cd11b-880a-4bd2-9ddf-4bf2cff3c0fa",
-            placementID: "preview_2f7cd11b",
-            title: "Easy Dice",
-            subtitle: "Simple modern animated dices",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/65/db/89/65db89f6-375e-fea7-41d4-9bf3ea0da135/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/easy-dice/id1514806286?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "b91a39b9-efda-423f-91b7-d21caa960672",
-            placementID: "preview_b91a39b9",
-            title: "Finalist Daily Planner",
-            subtitle: "Life Organizer for Home & Away",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/cf/49/f8/cf49f8f8-9dd1-07b5-a0d2-ce29bc7a1272/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/finalist-daily-planner/id6447014685?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "e5e31c88-ef22-4aec-a796-73e7085cc493",
-            placementID: "preview_e5e31c88",
-            title: "Nihongo - Japanese Study Tool",
-            subtitle: "Camera lookup, smart flashcards, and deep kanji insights",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7e/5d/47/7e5d47b4-e4fc-a4e6-edf9-df8d6f286053/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id881697245?pt=127247052&ct=guild-ads&mt=8") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "1fc7043b-424d-4791-9632-a2948bdc3404",
-            placementID: "preview_1fc7043b",
-            title: "Rainy Skies",
-            subtitle: "Beautiful Weather at a Glance",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3d/f1/d7/3df1d7c6-cffc-d4ed-c00d-c996e7b00ea5/LiquidGlass1-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/rainy-skies/id1637453069?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "8c90566d-bcef-445a-98cb-fad56fbfe971",
-            placementID: "preview_8c90566d",
-            title: "Mostly Good Metrics",
-            subtitle: "Drop in an SDK, Track events, funnels, and retention.",
-            iconURL: URL(string: "https://mostlygoodmetrics.com/images/og-image-icon.png"),
-            destinationURL: URL(string: "https://mostlygoodmetrics.com") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "716db9cd-c010-435f-b261-4eed7ef04455",
-            placementID: "preview_716db9cd",
-            title: "Scoreless",
-            subtitle: "Check soccer matches without spoiling the score.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cc/24/87/cc2487c8-7907-0ea3-61d3-8caf5751f976/AppIcon-0-1x_U007ephone-0-1-0-85-220-0.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/scoreless/id6523435481?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "8600d6df-2253-437d-9df8-fa8fa59deee8",
-            placementID: "preview_8600d6df",
-            title: "Tripsy: Travel Planner",
-            subtitle: "Organize all your trips in one place.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ef/73/9b/ef739b42-3be2-91b4-6c96-1d90327a7504/App_Icon_Original-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220-0.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/tripsy-travel-planner/id1429967544?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "7b280370-165c-4868-a0ab-546ed0afb304",
-            placementID: "preview_7b280370",
-            title: "Thrive: Financial Intelligence",
-            subtitle: "Ask. Learn. Grow your money.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/bf/ee/52/bfee52cf-85b2-3b21-a496-c1531153e145/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/thrive-financial-intelligence/id6741694500?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "cc348edd-8bb9-4a8f-a303-54cdcab0f1b6",
-            placementID: "preview_cc348edd",
-            title: "Scores for NCAA Sports",
-            subtitle: "Stats and scores for most NCAA Division 1,2 and 3 sports",
-            iconURL: URL(string: "https://scoresforncaa.com/assets/images/app-store-icon.jpeg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/scores-for-ncaa-sports/id6739069456") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "cbc6f449-bf7b-4a3d-be19-38008729eb65",
-            placementID: "preview_cbc6f449",
-            title: "Tiny Docs",
-            subtitle: "PDF Editing Made Simple.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/25/58/99/25589910-89b6-144f-01b3-538f744fb607/AppIconRed-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/tiny-docs/id6758741132?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "5cc8d777-7eb9-4079-8101-bedf8285657e",
-            placementID: "preview_5cc8d777",
-            title: "iCloud Photos & Drive Backup",
-            subtitle: "Parachute Backup - Protect Your Precious Memories.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fa/08/9b/fa089baf-6010-3d33-a89e-b295c9d7e15f/Parachute-iOS-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6749824842?pt=125087879&ct=ppc-guildads&mt=8") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "1582b656-abb5-4e62-9f51-53074e68b0dc",
-            placementID: "preview_1582b656",
-            title: "Overcast",
-            subtitle: "A very good podcast app.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/89/f0/0f/89f00fac-ab2f-bb30-e772-db3e514e3943/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id888422857?pt=4432800&ct=Guild%20Ads&mt=8") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "73c0fa92-8fc3-459f-888b-edf7cb705732",
-            placementID: "preview_73c0fa92",
-            title: "App Store",
-            subtitle: "Download MTG Scanner - Lion’s Eye by Orlando Gabriel Herrera on the App Store. See screenshots, ratings and reviews, user tips, and more apps like MTG Scanner -…",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/48/4e/6c/484e6c32-8f87-6f32-a791-4864afcd95f0/Placeholder.mill/1200x630wa.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/mtg-scanner-lions-eye/id1546754798") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "82ac3fbe-c324-4998-ad66-a6dbde46f0f7",
-            placementID: "preview_82ac3fbe",
-            title: "Alpenglow: Sunset Predictions",
-            subtitle: "Golden Hour Times",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/b6/c7/0f/b6c70ff4-a594-e667-9894-5675ea16776a/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/sunset-predictions-alpenglow/id978589174?uo=4&ct=Guild") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "3e0384da-8569-4478-9ef0-89d767b4a8af",
-            placementID: "preview_3e0384da",
-            title: "Here 2 There - Instant Navigation",
-            subtitle: "Save your favorite places. Get there fast.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/50/0e/16/500e169f-8a61-8566-060f-511c1d205932/Here2ThereIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6751860553?pt=2108296&ct=guild&mt=8") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "0cbfa1aa-eee9-4cd4-8152-83a84dc5315f",
-            placementID: "preview_0cbfa1aa",
-            title: "Tethered - rope survival game",
-            subtitle: "Don't cut the rope!",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fb/31/6d/fb316d8c-4ab2-9116-8bbf-4d65b7ff9b7a/TetheredIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6755638434?pt=2108296&ct=guild&mt=8") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "1b584edb-2bfc-465a-9c87-9327a55d33d3",
-            placementID: "preview_1b584edb",
-            title: "Letters - daily word game",
-            subtitle: "Spell words. Earn points. Beat your friends.",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/65/db/c5/65dbc5ae-5bb8-ab2d-57ad-a0ed350c7992/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6741609921?pt=2108296&ct=guild&mt=8") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "743bd6d8-3379-4a4e-a8e6-851d09dc6b8f",
-            placementID: "preview_743bd6d8",
-            title: "Tinseltown: Watchlist & Streaming Tracker",
-            subtitle: "Find new things to watch and where to watch them",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/71/4c/c3/714cc327-9a90-3da1-983d-287a0ecbf2e2/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/tinseltown-movie-tv-tracker/id6480349413?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "5be6f944-f447-4ee3-b1b3-49a88deaabf6",
-            placementID: "preview_5be6f944",
-            title: "Tasks: Todo Lists & Kanban",
-            subtitle: "The most customizable and native task manager for Apple's platforms!",
-            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/21/59/5a/21595af7-1160-de8f-3b35-0ad2915c26db/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"),
-            destinationURL: URL(string: "https://apps.apple.com/us/app/tasks-todo-lists-kanban/id1502903102?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "0893722b-cdfe-4ac9-8c5a-e620a4a1aed6",
-            placementID: "preview_0893722b",
-            title: "KeepCount: Tally Counter",
-            subtitle: "Fast, tactile scoreboard",
-            iconURL: nil,
-            destinationURL: URL(string: "https://apps.apple.com/us/app/keepcount-tally-counter/id6758891370?uo=4") ?? URL(string: "https://guildads.com")!
-        ),
-        GuildAd(
-            id: "afa19d0b-e338-40ac-8ee7-d3175e1b1bee",
-            placementID: "preview_afa19d0b",
-            title: "Sticky Widgets",
-            subtitle: "Simple Home Screen notes",
-            iconURL: nil,
-            destinationURL: URL(string: "https://apps.apple.com/us/app/sticky-widgets/id1533254320?uo=4") ?? URL(string: "https://guildads.com")!
+            id: "preview_guild_ads",
+            placementID: "preview_guild_ads",
+            title: "Guild Ads",
+            subtitle: "The indie-friendly, privacy-respecting ad network",
+            iconURL: URL(string: "https://guildads.com/logo-1024.png"),
+            destinationURL: URL(string: "https://guildads.com")!
         )
     ]
 }

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -90,19 +90,29 @@ private struct GuildAdsBannerPalette {
 public struct GuildAdsBanner: View {
     private let placementID: String
     private let style: GuildAdsBannerStyle
+    private let previewAd: GuildAd?
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
-    @StateObject private var viewModel = GuildAdsBannerViewModel()
+    @StateObject private var viewModel: GuildAdsBannerViewModel
 
     public init(placementID: String, style: GuildAdsBannerStyle = .automatic) {
         self.placementID = placementID
         self.style = style
+        self.previewAd = nil
+        _viewModel = StateObject(wrappedValue: GuildAdsBannerViewModel())
+    }
+
+    init(previewAd: GuildAd, style: GuildAdsBannerStyle = .automatic) {
+        self.placementID = previewAd.placementID
+        self.style = style
+        self.previewAd = previewAd
+        _viewModel = StateObject(wrappedValue: GuildAdsBannerViewModel(initialAd: previewAd))
     }
 
     public var body: some View {
         VStack {
-            if let ad = viewModel.ad {
+            if let ad = activeAd {
                 Button {
                     openAd(ad, source: "tap")
                 } label: {
@@ -125,21 +135,27 @@ public struct GuildAdsBanner: View {
                 .dynamicTypeSize(.small ... .xLarge)
                 .textCase(nil)
                 .multilineTextAlignment(.leading)
-                .transaction { transaction in
-                    transaction.animation = nil
-                }
             }
         }
         .task(id: placementID) {
+            guard !isPreviewMode else {
+                return
+            }
             await viewModel.load(placementID: placementID, theme: resolvedTheme)
         }
         .onAppear {
+            guard !isPreviewMode else {
+                return
+            }
             viewModel.beginAppearance()
             Task {
                 await viewModel.reportImpressionIfNeeded(placementID: placementID, theme: resolvedTheme)
             }
         }
         .onChange(of: viewModel.ad?.id) { _ in
+            guard !isPreviewMode else {
+                return
+            }
             Task {
                 await viewModel.reportImpressionIfNeeded(placementID: placementID, theme: resolvedTheme)
             }
@@ -179,7 +195,18 @@ public struct GuildAdsBanner: View {
             }
             #endif
         }
+        guard !isPreviewMode else {
+            return
+        }
         viewModel.handleTap(placementID: placementID)
+    }
+
+    private var activeAd: GuildAd? {
+        previewAd ?? viewModel.ad
+    }
+
+    private var isPreviewMode: Bool {
+        previewAd != nil
     }
 
     private var resolvedTheme: GuildAdsTheme {
@@ -224,12 +251,14 @@ public struct GuildAdsBanner: View {
     }
 
     private func bannerCard(for ad: GuildAd) -> some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 0) {
             iconView(for: ad)
+                .padding(.trailing, 8)
 
             adTextView(for: ad)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-            Spacer(minLength: 2)
+            Spacer(minLength: 8)
 
             Text("Get")
                 .font(.caption.weight(.semibold))
@@ -239,11 +268,12 @@ public struct GuildAdsBanner: View {
                 .background(Color.white)
                 .clipShape(Capsule())
                 .shadow(color: Color.black.opacity(0.14), radius: 3, x: 0, y: 1)
+                .fixedSize(horizontal: true, vertical: true)
         }
-        .padding(12)
+        .padding(8)
         .padding(.trailing, 20)
         .frame(maxWidth: GuildAdsBannerLayout.maxWidth)
-        .frame(minHeight: GuildAdsBannerLayout.height, maxHeight: GuildAdsBannerLayout.height)
+        .frame(maxHeight: GuildAdsBannerLayout.height)
         .background {
             cardBackground
         }
@@ -282,20 +312,29 @@ public struct GuildAdsBanner: View {
 
     private func adTextView(for ad: GuildAd) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(ad.title)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(palette.textColor)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .minimumScaleFactor(0.85)
+            GuildAdsMarqueeText(
+                text: ad.title,
+                font: .subheadline.weight(.semibold),
+                color: palette.textColor,
+                measureFont: titleMeasureFont
+            )
 
             Text(ad.subtitle)
                 .font(.caption)
                 .foregroundStyle(palette.subtitleColor)
                 .lineLimit(2)
                 .truncationMode(.tail)
-                .minimumScaleFactor(0.85)
+                .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private var titleMeasureFont: GuildAdsBannerPlatformFont {
+        #if canImport(UIKit)
+        let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .subheadline)
+        return UIFont.systemFont(ofSize: descriptor.pointSize, weight: .semibold)
+        #elseif canImport(AppKit)
+        return NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
+        #endif
     }
 
     private var adRailView: some View {
@@ -340,10 +379,119 @@ public struct GuildAdsBanner: View {
     }
 }
 
+private struct GuildAdsMarqueeText: View {
+    let text: String
+    let font: Font
+    let color: Color
+    let measureFont: GuildAdsBannerPlatformFont
+
+    private let spacing: CGFloat = 18
+    private let pointsPerSecond: CGFloat = 30
+    private let pauseDuration: TimeInterval = 3
+
+    @State private var cycleStart = Date()
+
+    var body: some View {
+        let stringWidth = text.guildAdsWidth(using: measureFont)
+        let stringHeight = text.guildAdsHeight(using: measureFont)
+        let gap = max(spacing, stringHeight * 1.5)
+        let distance = stringWidth + gap
+
+        return GeometryReader { geo in
+            let needsScrolling = stringWidth > geo.size.width
+
+            ZStack(alignment: .leading) {
+                if needsScrolling {
+                    TimelineView(.periodic(from: .now, by: 1.0 / 30.0)) { context in
+                        marqueeTrack(
+                            at: context.date,
+                            distance: distance,
+                            spacing: gap,
+                            laneWidth: geo.size.width
+                        )
+                    }
+                } else {
+                    baseText
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .minimumScaleFactor(0.85)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .clipped()
+            .onAppear {
+                cycleStart = Date()
+            }
+            .onChange(of: text) { _ in
+                cycleStart = Date()
+            }
+            .onChange(of: geo.size.width) { _ in
+                cycleStart = Date()
+            }
+        }
+        .frame(height: stringHeight)
+    }
+
+    private var baseText: some View {
+        Text(text)
+            .font(font)
+            .foregroundStyle(color)
+    }
+
+    private var scrollingText: some View {
+        baseText
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func marqueeTrack(at date: Date, distance: CGFloat, spacing: CGFloat, laneWidth: CGFloat) -> some View {
+        let travelDuration = max(0.1, Double(distance / pointsPerSecond))
+        let cycleDuration = pauseDuration + travelDuration
+        let elapsed = date.timeIntervalSince(cycleStart)
+        let cycleTime = elapsed.truncatingRemainder(dividingBy: cycleDuration)
+
+        let offset: CGFloat
+        if cycleTime < pauseDuration {
+            offset = 0
+        } else {
+            let travelTime = cycleTime - pauseDuration
+            offset = -min(distance, CGFloat(travelTime) * pointsPerSecond)
+        }
+
+        return HStack(spacing: spacing) {
+            scrollingText
+            scrollingText
+        }
+        .offset(x: offset)
+        .frame(width: laneWidth, alignment: .leading)
+        .clipped()
+    }
+}
+
+private extension String {
+    func guildAdsWidth(using font: GuildAdsBannerPlatformFont) -> CGFloat {
+        #if canImport(UIKit)
+        return (self as NSString).size(withAttributes: [.font: font]).width
+        #elseif canImport(AppKit)
+        return (self as NSString).size(withAttributes: [.font: font]).width
+        #endif
+    }
+
+    func guildAdsHeight(using font: GuildAdsBannerPlatformFont) -> CGFloat {
+        #if canImport(UIKit)
+        return (self as NSString).size(withAttributes: [.font: font]).height
+        #elseif canImport(AppKit)
+        return (self as NSString).size(withAttributes: [.font: font]).height
+        #endif
+    }
+}
+
 #if canImport(UIKit)
 private typealias GuildAdsBannerPlatformImage = UIImage
+private typealias GuildAdsBannerPlatformFont = UIFont
 #elseif canImport(AppKit)
 private typealias GuildAdsBannerPlatformImage = NSImage
+private typealias GuildAdsBannerPlatformFont = NSFont
 #endif
 
 private struct GuildAdsBannerMarkView: View {
@@ -508,6 +656,10 @@ private final class GuildAdsBannerViewModel: ObservableObject {
     @Published var ad: GuildAd?
     private var impressionReportedAdID: String?
 
+    init(initialAd: GuildAd? = nil) {
+        self.ad = initialAd
+    }
+
     func load(placementID: String, theme: GuildAdsTheme) async {
         #if DEBUG
         print("[GuildAds] Banner load for placement '\(placementID)'")
@@ -568,3 +720,206 @@ private final class GuildAdsBannerViewModel: ObservableObject {
         }
     }
 }
+
+#if DEBUG
+#Preview("Marquee Demo (Overflow)") {
+    GuildAdsBanner(
+        previewAd: GuildAd(
+            id: "preview_marquee_demo",
+            placementID: "preview_marquee_demo",
+            title: "This is an intentionally very long banner title to demonstrate marquee scrolling",
+            subtitle: "Marquee should move left continuously when title exceeds width.",
+            iconURL: nil,
+            destinationURL: URL(string: "https://guildads.com")!
+        ),
+        style: .automatic
+    )
+    .frame(width: 320)
+    .padding()
+}
+
+#Preview("All Supabase Campaign Creatives") {
+    ScrollView {
+        VStack(spacing: 10) {
+            ForEach(GuildAdsBannerPreviewFixtures.allAds) { ad in
+                GuildAdsBanner(previewAd: ad, style: .automatic)
+            }
+        }
+        .padding()
+    }
+    .frame(maxWidth: 420)
+}
+
+private enum GuildAdsBannerPreviewFixtures {
+    static let allAds: [GuildAd] = [
+        GuildAd(
+            id: "2f7cd11b-880a-4bd2-9ddf-4bf2cff3c0fa",
+            placementID: "preview_2f7cd11b",
+            title: "Easy Dice",
+            subtitle: "Simple modern animated dices",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/65/db/89/65db89f6-375e-fea7-41d4-9bf3ea0da135/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/easy-dice/id1514806286?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "b91a39b9-efda-423f-91b7-d21caa960672",
+            placementID: "preview_b91a39b9",
+            title: "Finalist Daily Planner",
+            subtitle: "Life Organizer for Home & Away",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/cf/49/f8/cf49f8f8-9dd1-07b5-a0d2-ce29bc7a1272/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/finalist-daily-planner/id6447014685?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "e5e31c88-ef22-4aec-a796-73e7085cc493",
+            placementID: "preview_e5e31c88",
+            title: "Nihongo - Japanese Study Tool",
+            subtitle: "Camera lookup, smart flashcards, and deep kanji insights",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7e/5d/47/7e5d47b4-e4fc-a4e6-edf9-df8d6f286053/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id881697245?pt=127247052&ct=guild-ads&mt=8") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "1fc7043b-424d-4791-9632-a2948bdc3404",
+            placementID: "preview_1fc7043b",
+            title: "Rainy Skies",
+            subtitle: "Beautiful Weather at a Glance",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3d/f1/d7/3df1d7c6-cffc-d4ed-c00d-c996e7b00ea5/LiquidGlass1-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/rainy-skies/id1637453069?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "8c90566d-bcef-445a-98cb-fad56fbfe971",
+            placementID: "preview_8c90566d",
+            title: "Mostly Good Metrics",
+            subtitle: "Drop in an SDK, Track events, funnels, and retention.",
+            iconURL: URL(string: "https://mostlygoodmetrics.com/images/og-image-icon.png"),
+            destinationURL: URL(string: "https://mostlygoodmetrics.com") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "716db9cd-c010-435f-b261-4eed7ef04455",
+            placementID: "preview_716db9cd",
+            title: "Scoreless",
+            subtitle: "Check soccer matches without spoiling the score.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cc/24/87/cc2487c8-7907-0ea3-61d3-8caf5751f976/AppIcon-0-1x_U007ephone-0-1-0-85-220-0.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/scoreless/id6523435481?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "8600d6df-2253-437d-9df8-fa8fa59deee8",
+            placementID: "preview_8600d6df",
+            title: "Tripsy: Travel Planner",
+            subtitle: "Organize all your trips in one place.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ef/73/9b/ef739b42-3be2-91b4-6c96-1d90327a7504/App_Icon_Original-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220-0.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/tripsy-travel-planner/id1429967544?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "7b280370-165c-4868-a0ab-546ed0afb304",
+            placementID: "preview_7b280370",
+            title: "Thrive: Financial Intelligence",
+            subtitle: "Ask. Learn. Grow your money.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/bf/ee/52/bfee52cf-85b2-3b21-a496-c1531153e145/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/thrive-financial-intelligence/id6741694500?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "cc348edd-8bb9-4a8f-a303-54cdcab0f1b6",
+            placementID: "preview_cc348edd",
+            title: "Scores for NCAA Sports",
+            subtitle: "Stats and scores for most NCAA Division 1,2 and 3 sports",
+            iconURL: URL(string: "https://scoresforncaa.com/assets/images/app-store-icon.jpeg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/scores-for-ncaa-sports/id6739069456") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "cbc6f449-bf7b-4a3d-be19-38008729eb65",
+            placementID: "preview_cbc6f449",
+            title: "Tiny Docs",
+            subtitle: "PDF Editing Made Simple.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/25/58/99/25589910-89b6-144f-01b3-538f744fb607/AppIconRed-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/tiny-docs/id6758741132?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "5cc8d777-7eb9-4079-8101-bedf8285657e",
+            placementID: "preview_5cc8d777",
+            title: "iCloud Photos & Drive Backup",
+            subtitle: "Parachute Backup - Protect Your Precious Memories.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fa/08/9b/fa089baf-6010-3d33-a89e-b295c9d7e15f/Parachute-iOS-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6749824842?pt=125087879&ct=ppc-guildads&mt=8") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "1582b656-abb5-4e62-9f51-53074e68b0dc",
+            placementID: "preview_1582b656",
+            title: "Overcast",
+            subtitle: "A very good podcast app.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/89/f0/0f/89f00fac-ab2f-bb30-e772-db3e514e3943/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id888422857?pt=4432800&ct=Guild%20Ads&mt=8") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "73c0fa92-8fc3-459f-888b-edf7cb705732",
+            placementID: "preview_73c0fa92",
+            title: "App Store",
+            subtitle: "Download MTG Scanner - Lion’s Eye by Orlando Gabriel Herrera on the App Store. See screenshots, ratings and reviews, user tips, and more apps like MTG Scanner -…",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/48/4e/6c/484e6c32-8f87-6f32-a791-4864afcd95f0/Placeholder.mill/1200x630wa.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/mtg-scanner-lions-eye/id1546754798") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "82ac3fbe-c324-4998-ad66-a6dbde46f0f7",
+            placementID: "preview_82ac3fbe",
+            title: "Alpenglow: Sunset Predictions",
+            subtitle: "Golden Hour Times",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/b6/c7/0f/b6c70ff4-a594-e667-9894-5675ea16776a/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/sunset-predictions-alpenglow/id978589174?uo=4&ct=Guild") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "3e0384da-8569-4478-9ef0-89d767b4a8af",
+            placementID: "preview_3e0384da",
+            title: "Here 2 There - Instant Navigation",
+            subtitle: "Save your favorite places. Get there fast.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/50/0e/16/500e169f-8a61-8566-060f-511c1d205932/Here2ThereIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6751860553?pt=2108296&ct=guild&mt=8") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "0cbfa1aa-eee9-4cd4-8152-83a84dc5315f",
+            placementID: "preview_0cbfa1aa",
+            title: "Tethered - rope survival game",
+            subtitle: "Don't cut the rope!",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fb/31/6d/fb316d8c-4ab2-9116-8bbf-4d65b7ff9b7a/TetheredIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6755638434?pt=2108296&ct=guild&mt=8") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "1b584edb-2bfc-465a-9c87-9327a55d33d3",
+            placementID: "preview_1b584edb",
+            title: "Letters - daily word game",
+            subtitle: "Spell words. Earn points. Beat your friends.",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/65/db/c5/65dbc5ae-5bb8-ab2d-57ad-a0ed350c7992/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/app/apple-store/id6741609921?pt=2108296&ct=guild&mt=8") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "743bd6d8-3379-4a4e-a8e6-851d09dc6b8f",
+            placementID: "preview_743bd6d8",
+            title: "Tinseltown: Watchlist & Streaming Tracker",
+            subtitle: "Find new things to watch and where to watch them",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/71/4c/c3/714cc327-9a90-3da1-983d-287a0ecbf2e2/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/tinseltown-movie-tv-tracker/id6480349413?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "5be6f944-f447-4ee3-b1b3-49a88deaabf6",
+            placementID: "preview_5be6f944",
+            title: "Tasks: Todo Lists & Kanban",
+            subtitle: "The most customizable and native task manager for Apple's platforms!",
+            iconURL: URL(string: "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/21/59/5a/21595af7-1160-de8f-3b35-0ad2915c26db/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"),
+            destinationURL: URL(string: "https://apps.apple.com/us/app/tasks-todo-lists-kanban/id1502903102?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "0893722b-cdfe-4ac9-8c5a-e620a4a1aed6",
+            placementID: "preview_0893722b",
+            title: "KeepCount: Tally Counter",
+            subtitle: "Fast, tactile scoreboard",
+            iconURL: nil,
+            destinationURL: URL(string: "https://apps.apple.com/us/app/keepcount-tally-counter/id6758891370?uo=4") ?? URL(string: "https://guildads.com")!
+        ),
+        GuildAd(
+            id: "afa19d0b-e338-40ac-8ee7-d3175e1b1bee",
+            placementID: "preview_afa19d0b",
+            title: "Sticky Widgets",
+            subtitle: "Simple Home Screen notes",
+            iconURL: nil,
+            destinationURL: URL(string: "https://apps.apple.com/us/app/sticky-widgets/id1533254320?uo=4") ?? URL(string: "https://guildads.com")!
+        )
+    ]
+}
+#endif

--- a/Sources/GuildAds/GuildAdsConfiguration.swift
+++ b/Sources/GuildAds/GuildAdsConfiguration.swift
@@ -34,7 +34,7 @@ public struct GuildAdsConfiguration: Sendable {
         baseURL: URL = URL(string: "https://guildads.com")!,
         prefetchPlacements: [String] = [],
         endpoints: GuildAdsEndpoints = .default,
-        sdkVersion: String = "0.1.0",
+        sdkVersion: String = "1.0.2",
         maxQueuedCalls: Int = 500
     ) {
         precondition(


### PR DESCRIPTION
## Summary
- disable live SDK networking in DEBUG by default to avoid real launch/serve/impression/click traffic during local testing
- add a built-in DEBUG mock ad in `GuildAdsBanner` (Guild Ads title/subtitle/logo) and skip impression/click side effects while mock mode is active
- keep an escape hatch for live debug traffic via `GUILDADS_ENABLE_LIVE_DEBUG=1`
- replace large preview fixture list with a single generic Guild Ads sample creative

## Why
SDK integrators commonly test in simulator/debug builds; this prevents polluting production metrics and accidental click/impression reporting during implementation testing.

## Validation
- `swift build` passes
