### PR TITLE
Use #if for checking if the app is running in the simulator.

### DIFF
--- a/Sources/GuildAds/GuildAds.swift
+++ b/Sources/GuildAds/GuildAds.swift
@@ -32,11 +32,11 @@ public enum GuildAds {
         if shouldDisableNetworkingForDebug {
             client = nil
             #if canImport(UIKit)
-            if targetEnvironment(simulator) {
+            #if targetEnvironment(simulator)
                 print("[GuildAds] DEBUG simulator mode: SDK networking disabled, showing mock banner creative.")
-            } else {
+            #else
                 print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
-            }
+            #endif
             #else
             print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
             #endif


### PR DESCRIPTION
Using Xcode 26.4, there was a compiler error when trying to use `if/else`. Not sure if I was overlooking something else, but switching to use `#if` got everything compiling again.