### PR TITLE
Fix visionOS build error and banner hover shape

### DIFF
--- a/Sources/GuildAds/GuildAds.swift
+++ b/Sources/GuildAds/GuildAds.swift
@@ -32,11 +32,11 @@ public enum GuildAds {
         if shouldDisableNetworkingForDebug {
             client = nil
             #if canImport(UIKit)
-            if targetEnvironment(simulator) {
-                print("[GuildAds] DEBUG simulator mode: SDK networking disabled, showing mock banner creative.")
-            } else {
-                print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
-            }
+            #if targetEnvironment(simulator)
+            print("[GuildAds] DEBUG simulator mode: SDK networking disabled, showing mock banner creative.")
+            #else
+            print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
+            #endif
             #else
             print("[GuildAds] DEBUG mode: SDK networking disabled, showing mock banner creative.")
             #endif

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -257,6 +257,10 @@ public struct GuildAdsBanner: View {
         }
     }
 
+    private var bannerShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+    }
+
     private func bannerCard(for ad: GuildAd) -> some View {
         HStack(spacing: 0) {
             iconView(for: ad)
@@ -284,17 +288,20 @@ public struct GuildAdsBanner: View {
         .background {
             cardBackground
         }
-        .contentShape(Rectangle())
+        .contentShape(bannerShape)
+        #if os(visionOS)
+        .contentShape(.hoverEffect, bannerShape)
+        #endif
         .clipped()
         .overlay(alignment: .trailing) {
             adRailView
         }
-        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .clipShape(bannerShape)
     }
 
     @ViewBuilder
     private var cardBackground: some View {
-        let shape = RoundedRectangle(cornerRadius: 14)
+        let shape = bannerShape
         if palette.usesGlass {
             #if os(visionOS)
             // glassEffect(_:in:) is unavailable on visionOS.


### PR DESCRIPTION
## Summary
- fix invalid runtime use of `targetEnvironment(simulator)` in `GuildAds.configure`
- use rounded banner shape for content hit-testing and visionOS hover effect
- reuse a shared rounded shape for background and clipping consistency

## Verification
- xcodebuild -project /Users/tylerhillsman/Desktop/VisionTest/VisionTest.xcodeproj -scheme VisionTest -configuration Debug -destination 'generic/platform=visionOS Simulator' build
