### PR TITLE
Fix issues #5, #6, #7: license, glass squeeze, icon caching

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Guild Ads, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import SwiftUI
 #if canImport(UIKit)
 import UIKit
@@ -365,26 +366,8 @@ public struct GuildAdsBanner: View {
             }
     }
 
-    @ViewBuilder
     private func iconView(for ad: GuildAd) -> some View {
-        AsyncImage(url: ad.iconURL) { phase in
-            switch phase {
-            case .success(let image):
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 34, height: 34)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-            default:
-                Image(systemName: "app.fill")
-                    .resizable()
-                    .symbolRenderingMode(.monochrome)
-                    .scaledToFit()
-                    .foregroundStyle(palette.textColor)
-                    .frame(width: 34, height: 34)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-            }
-        }
+        GuildAdsBannerIconView(url: ad.iconURL, placeholderColor: palette.textColor)
     }
 }
 
@@ -684,6 +667,185 @@ private actor GuildAdsBannerMarkCache {
         return baseURL
             .appendingPathComponent("com.guildads.sdk", isDirectory: true)
             .appendingPathComponent("banner-icon.png")
+    }
+
+    private static func decodeImage(from data: Data) -> GuildAdsBannerPlatformImage? {
+        #if canImport(UIKit)
+        return UIImage(data: data)
+        #elseif canImport(AppKit)
+        return NSImage(data: data)
+        #endif
+    }
+}
+
+private struct GuildAdsBannerIconView: View {
+    let url: URL?
+    let placeholderColor: Color
+
+    @StateObject private var loader = GuildAdsBannerIconLoader()
+
+    var body: some View {
+        ZStack {
+            if let image = loader.image {
+                image
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(systemName: "app.fill")
+                    .resizable()
+                    .symbolRenderingMode(.monochrome)
+                    .scaledToFit()
+                    .foregroundStyle(placeholderColor)
+            }
+        }
+        .frame(width: 34, height: 34)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .task(id: url) {
+            await loader.load(url: url)
+        }
+    }
+}
+
+@MainActor
+private final class GuildAdsBannerIconLoader: ObservableObject {
+    @Published var image: Image?
+    private var loadedURL: URL?
+
+    func load(url: URL?) async {
+        guard let url else {
+            image = nil
+            loadedURL = nil
+            return
+        }
+
+        if loadedURL == url, image != nil {
+            return
+        }
+
+        guard let platformImage = await GuildAdsBannerIconCache.shared.image(for: url) else {
+            return
+        }
+
+        #if canImport(UIKit)
+        image = Image(uiImage: platformImage)
+        #elseif canImport(AppKit)
+        image = Image(nsImage: platformImage)
+        #endif
+        loadedURL = url
+    }
+}
+
+private actor GuildAdsBannerIconCache {
+    static let shared = GuildAdsBannerIconCache()
+
+    private var memoryCache: [URL: GuildAdsBannerPlatformImage] = [:]
+    private let session: URLSession
+    private let cacheDirectoryURL: URL?
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.requestCachePolicy = .returnCacheDataElseLoad
+        config.urlCache = URLCache(
+            memoryCapacity: 8 * 1024 * 1024,
+            diskCapacity: 32 * 1024 * 1024,
+            diskPath: "com.guildads.ad-icon-cache"
+        )
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+
+        session = URLSession(configuration: config)
+        cacheDirectoryURL = Self.makeCacheDirectoryURL()
+    }
+
+    func image(for url: URL) async -> GuildAdsBannerPlatformImage? {
+        if let cached = memoryCache[url] {
+            return cached
+        }
+
+        if let diskImage = loadDiskImage(for: url) {
+            memoryCache[url] = diskImage
+            return diskImage
+        }
+
+        let request = URLRequest(
+            url: url,
+            cachePolicy: .returnCacheDataElseLoad,
+            timeoutInterval: 15
+        )
+
+        if let cachedResponse = session.configuration.urlCache?.cachedResponse(for: request),
+           let cachedImage = Self.decodeImage(from: cachedResponse.data) {
+            memoryCache[url] = cachedImage
+            persistToDisk(cachedResponse.data, for: url)
+            return cachedImage
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200...299).contains(httpResponse.statusCode) {
+                return nil
+            }
+
+            guard let networkImage = Self.decodeImage(from: data) else {
+                return nil
+            }
+
+            session.configuration.urlCache?.storeCachedResponse(
+                CachedURLResponse(response: response, data: data),
+                for: request
+            )
+            persistToDisk(data, for: url)
+            memoryCache[url] = networkImage
+            return networkImage
+        } catch {
+            return nil
+        }
+    }
+
+    private func loadDiskImage(for url: URL) -> GuildAdsBannerPlatformImage? {
+        guard let fileURL = diskFileURL(for: url),
+              let data = try? Data(contentsOf: fileURL) else {
+            return nil
+        }
+
+        return Self.decodeImage(from: data)
+    }
+
+    private func persistToDisk(_ data: Data, for url: URL) {
+        guard let fileURL = diskFileURL(for: url) else {
+            return
+        }
+
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private func diskFileURL(for url: URL) -> URL? {
+        guard let cacheDirectoryURL else {
+            return nil
+        }
+
+        let hash = SHA256.hash(data: Data(url.absoluteString.utf8))
+        let hashString = hash.map { String(format: "%02x", $0) }.joined()
+        let pathExtension = url.pathExtension
+        let filename = pathExtension.isEmpty ? hashString : "\(hashString).\(pathExtension)"
+        return cacheDirectoryURL.appendingPathComponent(filename)
+    }
+
+    private static func makeCacheDirectoryURL() -> URL? {
+        let baseURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+
+        return baseURL
+            .appendingPathComponent("com.guildads.sdk", isDirectory: true)
+            .appendingPathComponent("ad-icons", isDirectory: true)
     }
 
     private static func decodeImage(from data: Data) -> GuildAdsBannerPlatformImage? {

--- a/Sources/GuildAds/GuildAdsBanner.swift
+++ b/Sources/GuildAds/GuildAdsBanner.swift
@@ -297,29 +297,16 @@ public struct GuildAdsBanner: View {
             adRailView
         }
         .clipShape(bannerShape)
+        .modifier(GuildAdsBannerGlassEffect(usesGlass: palette.usesGlass, shape: bannerShape))
     }
 
     @ViewBuilder
     private var cardBackground: some View {
         let shape = bannerShape
         if palette.usesGlass {
-            #if os(visionOS)
-            // glassEffect(_:in:) is unavailable on visionOS.
             shape
                 .fill(.ultraThinMaterial)
                 .overlay(shape.stroke(palette.cardStrokeColor, lineWidth: 1))
-            #else
-            if #available(iOS 26, macOS 26, *) {
-                shape
-                    .fill(.ultraThinMaterial)
-                    .glassEffect(.regular.interactive(), in: shape)
-                    .overlay(shape.stroke(palette.cardStrokeColor, lineWidth: 1))
-            } else {
-                shape
-                    .fill(.ultraThinMaterial)
-                    .overlay(shape.stroke(palette.cardStrokeColor, lineWidth: 1))
-            }
-            #endif
         } else if palette.usesVibrantMaterial {
             shape
                 .fill(.thinMaterial)
@@ -398,6 +385,24 @@ public struct GuildAdsBanner: View {
                     .clipShape(RoundedRectangle(cornerRadius: 8))
             }
         }
+    }
+}
+
+private struct GuildAdsBannerGlassEffect: ViewModifier {
+    let usesGlass: Bool
+    let shape: RoundedRectangle
+
+    func body(content: Content) -> some View {
+        #if os(visionOS)
+        // glassEffect(_:in:) is unavailable on visionOS.
+        content
+        #else
+        if usesGlass, #available(iOS 26, macOS 26, *) {
+            content.glassEffect(.regular.interactive(), in: shape)
+        } else {
+            content
+        }
+        #endif
     }
 }
 


### PR DESCRIPTION
Addresses three open issues, one commit each.

## Summary

- **#5 — Add MIT `LICENSE.md`** ([7116973](../commit/7116973)). Lets dependency-license tooling like LicensePlist pick the package up.
- **#6 — Interactive glass squeeze affects the whole banner** ([4d29f57](../commit/4d29f57)). Previously `glassEffect(.regular.interactive(), in:)` was applied to the inner card background shape, so the squeeze gesture only deformed the background while the AD rail overlay stayed put. The effect now lives on the outer banner view (applied once after `clipShape`) via a small `ViewModifier` that's a no-op on visionOS and pre-iOS-26.
- **#7 — Cache ad icons for offline display** ([385a4d1](../commit/385a4d1)). The banner used `AsyncImage` for the icon, so it re-fetched on every appearance and fell back to the placeholder when offline — even though the ad copy itself rendered from the on-disk ad cache. Added a per-URL `GuildAdsBannerIconCache` (memory + disk + `URLCache`) modeled on the existing `GuildAdsBannerMarkCache`, and routed the icon through it. Cached icons now survive launches and render immediately when offline.

## Test plan

- [x] `swift build` — clean.
- [x] `xcodebuild -scheme GuildAdsSDK -destination "generic/platform=iOS Simulator" build` — succeeded.
- [ ] Manually verify on iOS 26 sim that dragging the banner squeezes the entire card (including the AD rail), not just the background.
- [ ] Manually verify in airplane mode (after a prior launch with network) that the ad icon renders from cache instead of falling back to the `app.fill` placeholder.

## Notes

`swift test` does not currently compile on `main` (test target calls `GuildAdsQueueStore.all()` without the required `restoringToken:` argument). Out of scope for this PR — flagging for a follow-up.