### PR TITLE
Fix queueStorePersistsCalls test compile error

### DIFF
--- a/Tests/GuildAdsTests/GuildAdsTests.swift
+++ b/Tests/GuildAdsTests/GuildAdsTests.swift
@@ -114,7 +114,7 @@ import Testing
     await store.enqueue(QueuedCall.launch(sampleLaunchPayload()), maxCount: 10)
 
     let reloaded = GuildAdsQueueStore(directoryURL: directory)
-    let calls = await reloaded.all()
+    let calls = await reloaded.all(restoringToken: "test_token")
 
     #expect(calls.count == 1)
     #expect(calls.first?.type == .launch)


### PR DESCRIPTION
## Summary

`swift test` doesn't compile on `main` — `queueStorePersistsCalls` calls `reloaded.all()` without the required `restoringToken:` argument that `GuildAdsQueueStore.all` takes. Pass a placeholder token so the test compiles and runs. The test only asserts on call count and type, so the value of the token is irrelevant.

## Test plan

- [x] `swift test` — all 6 tests pass.