### PR TITLE
Mention the Guild Ads CLI in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,18 @@ let fresh = await GuildAds.refreshAd(for: "settings_footer")
 
 Both methods return `nil` if no ad is available. Impression and click tracking are handled by `GuildAdsBanner` and are not part of the manual load path.
 
+## Manage your account from the CLI
+
+Your apps, SDK tokens, campaigns, and earnings are also accessible from the terminal via the [Guild Ads CLI](https://www.npmjs.com/package/guild-ads):
+
+```bash
+npm install -g guild-ads
+guild-ads auth login
+guild-ads tokens create --app <appId> --name "Production"
+```
+
+Every command supports `--json` output, so you can script account setup or wire it into other tooling. Run `guild-ads --help` for the full command tree.
+
 ## API and dashboard
 
 Once you've signed up at [guildads.com](https://guildads.com), your dashboard has full API documentation. The SDK handles all network communication automatically -- you don't need to call the API directly.


### PR DESCRIPTION
## Summary

- Adds a "Manage your account from the CLI" section pointing to the newly published [`guild-ads`](https://www.npmjs.com/package/guild-ads) npm package
- Places it right before the "API and dashboard" section since both cover platform access beyond the SDK
- Includes the most relevant snippet for iOS publishers: install, login, generate an SDK token

## Test plan

- [x] Read the rendered Markdown to confirm formatting
- [ ] Confirm the npm link resolves once published (already live: https://www.npmjs.com/package/guild-ads)